### PR TITLE
Dockerfile: bump Alpine Linux from 3.10 to 3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.18
 
 # TODO: install packages required to run the representer
 RUN apk add --no-cache bash jq


### PR DESCRIPTION
For more details, see the list of [Alpine Linux releases][1].

[1]: https://alpinelinux.org/releases/